### PR TITLE
feat: add a `tests` options to contracts, to specify the number of tests to be generated

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -106,6 +106,9 @@ Testify reads a list of contracts in a toml file.
 - **`inputs`** *(array of `Input` tables)*  
   Each entry describes one input necessary for the contract. Inputs can either define a value-like input or a type parameter. See **`Input`** below.
 
+- **`tests`** *(positive integer, default to `5`)*
+  The numbers of tests to generate for this contract.
+
 ### `Input`
 
 Each `Input` is specified within `[[inputs]]` arrays. An `Input` always has:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,11 @@ impl Default for DependencySpec {
     }
 }
 
+/// Default number of tests to run
+fn default_tests_number() -> usize {
+    5
+}
+
 /// A `Contract` defines a set of inputs, a description, a precondition, and a postcondition.
 /// It can also contain additional data such as dependencies, use-statements, and an optional
 /// tested function. Contracts can be instantiated with concrete inputs and then evaluated.
@@ -115,6 +120,9 @@ pub struct Contract {
     /// The function under test, if any, represented by a `syn::Path`.
     #[serde(with = "serde_via::SerdeVia")]
     pub function_tested: Option<syn::Path>,
+    /// Number of tests to generate. 5 by default.
+    #[serde(default = "default_tests_number")]
+    pub tests: usize,
 }
 
 impl Contract {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,5 +1,5 @@
-use crate::krate::Krate;
 use crate::prelude::*;
+use crate::{default_tests_number, krate::Krate};
 
 /// Represents the context needed to generate a prompt for contract generation.
 /// This includes the item being tested, its contents, related items, and related contracts.
@@ -29,6 +29,7 @@ impl Contract {
             dependencies: HashMap::new(),
             use_statements: vec![],
             function_tested: None,
+            tests: default_tests_number(),
         }
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -320,8 +320,8 @@ impl ContractPool<ParametricContracts> {
         let mut instantiated_contracts = vec![];
         for (i, contract) in self.contracts.iter().enumerate() {
             let mut instances = vec![];
-            for _ in 1..100 {
-                if instances.len() >= 5 {
+            for _ in 1..(contract.tests * 20) {
+                if instances.len() >= contract.tests {
                     break;
                 }
                 let types = &self.state.types[i];

--- a/tests/coverage/main.rs
+++ b/tests/coverage/main.rs
@@ -25,9 +25,11 @@ example-crate = {{path = "{}/tests/coverage/example-crate"}}
                 std::env!("CARGO_MANIFEST_DIR")
             ))
             .unwrap(),
+            tests: 5,
             use_statements: vec![syn::parse_quote! {abstractions::*}],
             function_tested: Some(parse_quote! {example_crate::add_or_zero}),
         }],
         "regressions.rs",
+        true,
     );
 }

--- a/tests/libcore_legacy_contracts/imported.rs
+++ b/tests/libcore_legacy_contracts/imported.rs
@@ -37,6 +37,7 @@ macro_rules! contract {
                 precondition: syn::parse_quote!{$pre_body},
                 postcondition: syn::parse_quote!{$post_body},
                 span: Span::dummy(),
+                tests: 5,
                 dependencies: toml::from_str(&format!(
                 r#"
 abstractions = {{path = "{}/abstractions"}}

--- a/tests/libcore_legacy_contracts/main.rs
+++ b/tests/libcore_legacy_contracts/main.rs
@@ -2,5 +2,5 @@ mod imported;
 
 fn main() {
     testify::driver::setup_tracing();
-    testify::driver::run(imported::contracts(), "regressions.rs");
+    testify::driver::run(imported::contracts(), "regressions.rs", false);
 }


### PR DESCRIPTION
Fixes #37 